### PR TITLE
add script html and change ios webview src(#7)

### DIFF
--- a/src/component/SpeechRecView.tsx
+++ b/src/component/SpeechRecView.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useContext} from 'react';
-import {View} from 'react-native';
+import {Platform, View} from 'react-native';
 import {WebView} from 'react-native-webview';
 import {SpeechRecContext} from '../context/SpeechRecProvider';
 import {speechRecScript} from '../static/speechRecScript';
@@ -12,6 +12,10 @@ interface MessageEvent {
 
 export const SpeechRecView = React.memo(() => {
   const {webViewRef, notifyListeners} = useContext(SpeechRecContext);
+  const webViewSrc = Platform.select({
+    ios: require("../static/speechRecScript.html"),
+    android: {html: speechRecScript}
+  })
 
   const onMessageReceived = useCallback(
     (event: any) => {
@@ -29,7 +33,7 @@ export const SpeechRecView = React.memo(() => {
       <WebView
         ref={webViewRef}
         originWhitelist={['*']}
-        source={{html: speechRecScript}}
+        source={webViewSrc}
         onMessage={onMessageReceived}
         onLoad={() => {
           console.log('🫵 🫵  Speech Rec Script View Loaded 🫵 🫵 ');

--- a/src/static/speechRecScript.html
+++ b/src/static/speechRecScript.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Speech Recognition Script</title>
+  </head>
+  <body>
+    <script>
+      let finalizedTranscript = "";
+      let transcriptResult = "";
+      let isListening = false;
+
+      // Check for browser compatibility
+      window.SpeechRecognition =
+        window.SpeechRecognition || window.webkitSpeechRecognition;
+      window.SpeechGrammarList =
+        window.SpeechGrammarList || window.webkitSpeechGrammarList;
+      window.SpeechRecognitionEvent =
+        window.SpeechRecognitionEvent || window.webkitSpeechRecognitionEvent;
+
+      if ("SpeechRecognition" in window) {
+        let recognition = new SpeechRecognition();
+        recognition.interimResults = true; // Get interim results
+
+        let isManualStop = false;
+
+        recognition.addEventListener("start", (event) => {
+          if (!isListening) {
+            isListening = true;
+            window.ReactNativeWebView.postMessage(
+              JSON.stringify({
+                type: "SpeechRecognitionStarted",
+                data: {},
+              })
+            );
+          }
+        });
+
+        recognition.addEventListener("result", (event) => {
+          let interimTranscript = "";
+          for (let i = event.resultIndex; i < event.results.length; ++i) {
+            if (event.results[i].isFinal) {
+              finalizedTranscript += " " + event.results[i][0].transcript;
+            } else {
+              interimTranscript += event.results[i][0].transcript;
+            }
+          }
+
+          transcriptResult = finalizedTranscript + " " + interimTranscript;
+
+          window.ReactNativeWebView.postMessage(
+            JSON.stringify({
+              type: "SpeechRecognitionRealTimeResult",
+              data: transcriptResult,
+            })
+          );
+        });
+
+        recognition.addEventListener("end", () => {
+          // If the speech recognition is ended because the speech rec engine decided that
+          // the user finishes speaking (e.g., user kept silent for a few seconds), we restart
+          // the speech rec process
+          if (!isManualStop) {
+            recognition.start();
+          } else {
+            isListening = false;
+
+            window.ReactNativeWebView.postMessage(
+              JSON.stringify({
+                type: "SpeechRecognitionEnd",
+                data: transcriptResult,
+              })
+            );
+          }
+        });
+
+        recognition.addEventListener("error", (event) => {
+          window.ReactNativeWebView.postMessage(
+            JSON.stringify({
+              type: "SpeechRecognitionError",
+              data: {
+                code: event.error,
+                errorMessage: event.message,
+              },
+            })
+          );
+        });
+
+        window.handleNativeEvent = function (message) {
+          switch (message.type) {
+            case "StartSpeechRecognition":
+              isManualStop = false;
+              isListening = false; // this will be set to true in start event listener
+              finalizedTranscript = "";
+              transcriptResult = "";
+
+              recognition.lang = message.data.language;
+              recognition.start();
+              break;
+
+            case "StopSpeechRecognition":
+              isManualStop = true;
+              recognition.stop();
+
+              break;
+
+            case "CancelSpeechRecognition":
+              isManualStop = true;
+              recognition.abort();
+
+              break;
+
+            default:
+              console.error("Unhandled WebView message type: ", message.type);
+              break;
+          }
+        };
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
related : #7 User permission check has failed

I have found that when bare HTML is embedded inside a WebView source, the navigator's mediaDevices property is unavailable.

This appears to be an issue related to cross-browser compatibility. I have observed that changing the source to a URI path resolves the issue and allows the functionality to work correctly

so I have changed the way to get the src of the IOS WebView.

You will need to change the source of SpeechRecView.js within the node modules in the same way as I did